### PR TITLE
Possibility to design with node-red-contrib-sm-ioplus without linux

### DIFF
--- a/node-red-contrib-sm-ioplus/i2c-mock.js
+++ b/node-red-contrib-sm-ioplus/i2c-mock.js
@@ -1,0 +1,26 @@
+module.exports = {
+    openSync: function(busNumber) {
+        console.log("--- [MOCK] I2C Bus " + busNumber + " opened ---");
+        return {
+            writeByte: (addr, cmd, val, cb) => { 
+                console.log("[MOCK] Write Byte -> Addr: 0x" + addr.toString(16) + " Reg: " + cmd + " Val: " + val);
+                if (cb) cb(null); 
+            },
+            writeWord: (addr, cmd, val, cb) => { 
+                console.log("[MOCK] Write Word -> Addr: 0x" + addr.toString(16) + " Reg: " + cmd + " Val: " + val);
+                if (cb) cb(null); 
+            },
+            readByte: (addr, cmd, cb) => { 
+                console.log("[MOCK] Read Byte <- Addr: 0x" + addr.toString(16) + " Reg: " + cmd);
+                if (cb) cb(null, 0); 
+            },
+            readI2cBlock: (addr, cmd, len, buffer, cb) => { 
+                console.log("[MOCK] Read Block <- Addr: 0x" + addr.toString(16) + " Reg: " + cmd + " Len: " + len);
+                // Fill buffer with fake data (e.g., all 0s)
+                buffer.fill(0);
+                if (cb) cb(null, len, buffer); 
+            },
+            closeSync: () => console.log("--- [MOCK] I2C Bus closed ---")
+        };
+    }
+};

--- a/node-red-contrib-sm-ioplus/ioplus.js
+++ b/node-red-contrib-sm-ioplus/ioplus.js
@@ -1,6 +1,6 @@
 module.exports = function(RED) {
     "use strict";
-    var I2C = require("i2c-bus");
+    var I2C; if (process.platform === "linux") { I2C = require("i2c-bus"); } else { I2C = require("./i2c-mock.js"); console.log("IOPLUS: Mac detected, using Mock."); }
     const DEFAULT_HW_ADD = 0x28;
 
     const I2C_MEM_RELAY_VAL_ADD = 0;   

--- a/node-red-contrib-sm-ioplus/package.json
+++ b/node-red-contrib-sm-ioplus/package.json
@@ -2,7 +2,7 @@
   "name": "node-red-contrib-sm-ioplus",
   "version": "1.0.3",
   "bundleDependencies": false,
-  "dependencies": {
+  "optionalDependencies": {
     "i2c-bus": "^5.2.0"
   },
   "deprecated": false,


### PR DESCRIPTION
Added this so node-red flows can be designed on non-i2c systems, like MacOS. 